### PR TITLE
Fix: split merged code blocks in jen build section (Issue #4)

### DIFF
--- a/docs/content/docs/cli.mdx
+++ b/docs/content/docs/cli.mdx
@@ -38,20 +38,24 @@ Generate a static site from all non-dynamic routes.
 
 <Tabs items={['npm', 'pnpm', 'yarn', 'bun']}>
   <Tab value="npm">
-    ```bash npx jen build npx jen build --adapter=vercel npx jen build
-    --adapter=cloudflare ```
+    ```bash npx jen build ```
+    ```bash npx jen build --adapter=vercel ```
+    ```bash npx jen build --adapter=cloudflare ```
   </Tab>
   <Tab value="pnpm">
-    ```bash pnpm jen build pnpm jen build --adapter=vercel pnpm jen build
-    --adapter=cloudflare ```
+    ```bash pnpm jen build ```
+    ```bash pnpm jen build --adapter=vercel ```
+    ```bash pnpm jen build --adapter=cloudflare ```
   </Tab>
   <Tab value="yarn">
-    ```bash yarn jen build yarn jen build --adapter=vercel yarn jen build
-    --adapter=cloudflare ```
+    ```bash yarn jen build ```
+    ```bash yarn jen build --adapter=vercel ```
+    ```bash yarn jen build --adapter=cloudflare ```
   </Tab>
   <Tab value="bun">
-    ```bash bunx jen build bunx jen build --adapter=vercel bunx jen build
-    --adapter=cloudflare ```
+    ```bash bunx jen build ```
+    ```bash bunx jen build --adapter=vercel ```
+    ```bash bunx jen build --adapter=cloudflare ```
   </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Description

Fixes Issue #4: Fix indentation or formatting in a documentation code example.

In the `jen build` command documentation section, three separate commands were merged into a single code block within each tab. This made the commands hard to read and copy.

## Type of Change

- [x] Documentation (documentation only)

## Changes

- `docs/content/docs/cli.mdx`: Split the three `jen build` commands into individual code blocks for each package manager tab (npm, pnpm, yarn, bun)

**Before:**
\`\`\`bash npx jen build npx jen build --adapter=vercel npx jen build --adapter=cloudflare \`\`\`

**After:**
\`\`\`bash npx jen build \`\`\`
\`\`\`bash npx jen build --adapter=vercel \`\`\`
\`\`\`bash npx jen build --adapter=cloudflare \`\`\`

## How Has This Been Tested

- [x] Documentation-only change (no code affected)

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my own changes
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings