### PR TITLE
Remove unused GoogleFont story import

### DIFF
--- a/packages/jen/src/stories/GoogleFont.stories.tsx
+++ b/packages/jen/src/stories/GoogleFont.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/preact-vite';
 import { GoogleFont } from '../fonts/google';
-import { h } from 'preact';
 
 const GoogleFontDemo = ({ fontName, text }: { fontName: string, text: string }) => {
   const font = GoogleFont(fontName, { weight: [400, 700], subsets: ['latin'] });


### PR DESCRIPTION
## Summary
- remove the unused `h` import from the GoogleFont Storybook story
- leave the story implementation unchanged

Refs #6

## Validation
- `npx eslint packages/jen/src/stories/GoogleFont.stories.tsx`
- `git diff --check`

Note: I also ran broader source lint while validating the issue and it still reports unrelated pre-existing errors in other files. This PR only addresses the unused import flagged in the GoogleFont story.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unnecessary import dependency, optimizing the codebase with no impact to functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->